### PR TITLE
Fix formfield image preview path

### DIFF
--- a/templates/Froxlor/form/formfields.html.twig
+++ b/templates/Froxlor/form/formfields.html.twig
@@ -165,7 +165,7 @@
 
 {% macro image(id, field) %}
 	{% if field.value is not empty %}
-		<img src="/{{ field.value }}" alt="Current Image" class="field-image-preview"><br>
+		<img src="{{ field.value }}" alt="Current Image" class="field-image-preview"><br>
 		<div class="form-check form-switch mb-2">
 			<input type="checkbox" value="1" name="{{ id }}_delete" class="form-check-input">
 			<label class="form-check-label">


### PR DESCRIPTION
Incorrect path for the image preview in form fields, if you do not run froxlor in root folder.